### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,17 +11,17 @@ EEPROM_CAT25	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin			KEYWORD2
-end			KEYWORD2
-readByte		KEYWORD2
-writeByte		KEYWORD2
-readBlock		KEYWORD2
-writeBlock		KEYWORD2
-writePage               KEYWORD2
-isReady                 KEYWORD2
-enableWrite             KEYWORD2
-disableWrite            KEYWORD2
-getStatusRegister       KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+readByte	KEYWORD2
+writeByte	KEYWORD2
+readBlock	KEYWORD2
+writeBlock	KEYWORD2
+writePage	KEYWORD2
+isReady	KEYWORD2
+enableWrite	KEYWORD2
+disableWrite	KEYWORD2
+getStatusRegister	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords